### PR TITLE
ci: add Python 3.8 to linter and test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.6", "3.7"]
+        python: ["3.6", "3.7", "3.8"]
     steps:
       - uses: actions/checkout@v1
       - name: Use Python ${{ matrix.python }}
@@ -40,7 +40,7 @@ jobs:
     needs: linter
     strategy:
       matrix:
-        python: ["3.6", "3.7"]
+        python: ["3.6", "3.7", "3.8"]
     steps:
       - uses: actions/checkout@v1
       - name: Use Python ${{ matrix.python }}


### PR DESCRIPTION
Fixes #2 

Add the most recent major Python release to our CI builds.